### PR TITLE
fix(cicd): Adicionar porta SSH ao job de deploy

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -79,6 +79,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: ${{ secrets.VPS_SSH_PORT }}
           script: |
             set -e # Exit immediately if a command exits with a non-zero status.
             echo "--- Conectado à VPS. Iniciando deploy... ---"


### PR DESCRIPTION
A conexão SSH estava falhando com timeout porque o parâmetro 'port' estava ausente.

Esta correção reintroduz o parâmetro 'port: ${{ secrets.VPS_SSH_PORT }}' na action 'appleboy/ssh-action', garantindo que a pipeline se conecte à porta correta do servidor SSH, conforme definido no segredo.